### PR TITLE
Version 0.0.5

### DIFF
--- a/md2pdf/doc.py
+++ b/md2pdf/doc.py
@@ -17,6 +17,7 @@ DEFAULT_MARKDOWN_EXTRAS = [
 
 class Document(object):
     _DEFAULT_WK_KWARGS = {
+        "--title": "",
         "--page-size": "A4",
         "--margin-top": "25mm",
         "--margin-bottom": "25mm",
@@ -47,7 +48,8 @@ class Document(object):
     @property
     def template(self):
         fn = Path(os.path.dirname(__file__)) / 'res/template.html'
-        return fn.open().read()
+        with fn.open() as f:
+            return f.read()
 
     @property
     def stylesheet(self):
@@ -56,7 +58,8 @@ class Document(object):
         else:
             fn = Path(os.path.dirname(__file__)) / 'res/css/github.css'
         assert fn.is_file()
-        return fn.open().read()
+        with fn.open() as f:
+            return f.read()
 
     @property
     def html_file_name(self):
@@ -84,6 +87,7 @@ class Document(object):
 
         wkargs = self._DEFAULT_WK_KWARGS.copy()
         wkargs['--title'] = self._file_name.name
+        wkargs['--allow'] = str(self._file_name.parent)
 
         # merge user specified wk arguments
         if extra_wkargs is not None:

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 from setuptools import setup, find_packages
-from pkg_resources import get_distribution
 
 with open("README.md", "r") as f:
     long_description = f.read()

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,3 @@
 flake8
 nose
+pillow

--- a/tests/test_md2pdf.py
+++ b/tests/test_md2pdf.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from unittest import TestCase
-
+from PIL import Image
 from md2pdf.doc import Document
 
 
@@ -19,6 +19,20 @@ class TestMd2Pdf(TestCase):
         test_md = "# Test"
         with TemporaryDirectory() as d:
             pd = Path(d)
+            test_md_file = pd / "test.md"
+            test_md_file.write_text(test_md)
+            doc = Document.from_markdown(test_md_file)
+            doc.save_to_pdf()
+            self.assertTrue(doc.pdf_file_name.exists())
+
+    def test_local_image(self):
+        image_name = "TestImage.jpg"
+        test_md = f"# Test\n![Test]({image_name})"
+        image = Image.new('RGB', size=(1, 1))
+
+        with TemporaryDirectory() as d:
+            pd = Path(d)
+            image.save(str(pd / image_name))
             test_md_file = pd / "test.md"
             test_md_file.write_text(test_md)
             doc = Document.from_markdown(test_md_file)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,flake8
+envlist = py37,py38,py39,flake8
 
 [testenv]
 commands = nosetests {posargs}
@@ -19,4 +19,4 @@ commands = flake8 {posargs}
 
 [flake8]
 max-line-length = 120
-exclude = .tox,.venv,build,dist,doc,git/ext/,.git,__pycache__
+exclude = .tox,.venv,venv,build,dist,doc,git/ext/,.git,__pycache__


### PR DESCRIPTION
* Adapt to wkhtmltopdf 0.12.6 default behavior  '--disable-local-file-access' by adding '--allow=md_path'
* Test against python 3.7, 3.8, 3.9