### PR TITLE
Set zip_safe flag to False to fix reading data_files error

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,20 @@
 Convert Markdown to PDF using markdown2 and wkhtmltopdf.
 
 ## Install
+
+Install the wkhtmltopdf package first, on Debian/Ubuntu:
+
 ```
-sudo pip install -r requirements.txt
-sudo python setup.py install
+sudo apt install wkhtmltopdf
+```
+
+And then install md2pdf to your Python environment:
+```
+pip install .
+```
+or:
+```
+python setup.py install
 ```
 
 ## Usage
@@ -17,3 +28,4 @@ python -m md2pdf <markdown-file.md>
 python -m md2pdf <markdown-file.md> -o <pdf-file.pdf>
 ```
 
+Please run `python -m md2pdf --help` to find more usage.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
 markdown2
 click
-wkhtmltopdf
-

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(name='md2pdf',
       url='https://github.com/walwe/md2pdf',
       packages=find_packages(),
       include_package_data=True,
+      zip_safe=False,
       author='walwe',
       license='MIT License',
       entry_points='''


### PR DESCRIPTION
The `python setup.py install` command will install the package as an egg
by default. But data_files is not supported when installing packages as
eggs. Though data files in a package can be read using
`importlib.resources` module, the module was new in version 3.7. So here
we can set zip_safe flag to False to avoid the package installed as an
egg for the support of >= Python 3.6 .

Document of data_files:
https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#data-files

Document of importlib.resources module:
https://docs.python.org/3/library/importlib.html#module-importlib.resources

Document of setting the zig_safe flag:
https://setuptools.pypa.io/en/latest/userguide/miscellaneous.html#setting-the-zip-safe-flag

Other references:

https://stackoverflow.com/questions/6301003/stopping-setup-py-from-installing-as-egg

https://stackoverflow.com/questions/49782111/access-a-file-from-a-python-egg